### PR TITLE
Fix DMARC strict alignment check according to RFC 7489

### DIFF
--- a/libopendmarc/opendmarc_policy.c
+++ b/libopendmarc/opendmarc_policy.c
@@ -307,6 +307,16 @@ opendmarc_policy_check_alignment(u_char *subdomain, u_char *tld, int mode)
 	if (strcasecmp(rev_tld, rev_sub) == 0)
 		return 0;
 
+	/*
+	 * For strict mode, only exact matches are allowed
+	 * as per RFC 7489 Section 3.1.1 and 3.1.2
+	 */
+	if (mode == DMARC_RECORD_A_STRICT)
+		return -1;
+
+	/*
+	 * For relaxed mode, check if domain or subdomain matches
+	 */
 	ret = strncasecmp(rev_tld, rev_sub, strlen(rev_tld));
 	if (ret == 0 && mode == DMARC_RECORD_A_RELAXED)
 			return 0;
@@ -324,12 +334,7 @@ opendmarc_policy_check_alignment(u_char *subdomain, u_char *tld, int mode)
 	if (*ep != '.')
 		(void) strlcat((char *)rev_tld, ".", sizeof rev_tld);
 
-	/*
-	 * Perfect match is aligned irrespective of relaxed or strict.
-	 */
-	if (strcasecmp(rev_tld, rev_sub) == 0)
-		return 0;
-
+	/* Check organizational domain match for relaxed mode */
 	ret = strncasecmp(rev_tld, rev_sub, strlen(rev_tld));
 	if (ret == 0 && mode == DMARC_RECORD_A_RELAXED)
 			return 0;


### PR DESCRIPTION
DMARCのstrictモードにおけるアライメントチェックの誤りを修正

現在の実装では、strictモードにおいて部分的なドメインの一致を誤って許可してしまいます。
RFC 7489の3.1.1項と3.1.2項では、strictアライメント(adkim=sまたはaspf=s)は
RFC5322.Fromのドメインと評価対象のドメインの完全一致を要求しています。

この問題はPublic Suffix Listが設定されている場合に発生します。
strictモードでの現在の誤った動作は以下の通りです：
From: user@sub.example.com, envelope from: sender@example.com の場合
1. 最初の完全一致で失敗（正しい：sub.example.com ≠ example.com）
2. ヘッダFromのドメインからTLD+1を取得（sub.example.comからexample.comを取得）
3. このTLD+1とenvelope fromを比較（example.com）
4. PASSを返す（strictモードでは不正）

注：Public Suffix Listが設定されていない場合、TLD解決は元のドメインをそのまま
返すため、この誤った一致は発生しません。

逆のケースは、Public Suffix Listの設定に関わらず正しく動作します：
From: user@example.com, envelope from: sender@sub.example.com の場合
1. 最初の完全一致で失敗
2. 以降のチェックも失敗
3. FAILを返す（strictモードでは正しい）

この問題は、SPF（aspf=s）とDKIM（adkim=s）の両方のアライメントチェックに
同様に影響します。これは両者が同じアライメントチェック関数を使用しているためです。

このパッチは：
1. strictモードで最初の完全一致が失敗した時点で即座に処理を終了するように変更
2. strictモードでのTLD解決に基づくマッチングを削除
3. relaxedモードの既存の動作は維持

これらの変更により、strictモードではドメインの完全一致のみを許可するという
RFC 7489の要件を正しく実装します。